### PR TITLE
Partial fix of Amplify deployment 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "metricspage",
       "version": "0.1.0",
       "dependencies": {
         "autoprefixer": "^10.1.0",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "dev": "next dev",
-    "build": "next build",
+    "build": "next build && next export",
     "start": "next start"
   },
   "dependencies": {


### PR DESCRIPTION
The Amplify deployment issue is solved by this suggestion: https://github.com/aws-amplify/amplify-console/issues/1176#issuecomment-732379186

Along with this PR, the build script needs to be changed by setting `baseDirectory: out`.

